### PR TITLE
REFACTOR invitation from email

### DIFF
--- a/src/Model/UserInvitation.php
+++ b/src/Model/UserInvitation.php
@@ -83,7 +83,7 @@ class UserInvitation extends DataObject
     public function sendInvitation()
     {
         $email = Email::create()
-            ->setFrom(Email::config()->get('admin_email'))
+            ->setFrom(Security::getCurrentUser()->Email)
             ->setTo($this->Email)
             ->setSubject(
                 _t(


### PR DESCRIPTION
Send from current user vs. admin_email.

If `admin_email` is not set in config it throws an error.