### PR TITLE
fix(#28): guard from_email resolution, add from_email config

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -3,6 +3,7 @@ Name: userinvitationconfig
 ---
 Dynamic\SilverStripe\UserInvitations\Model\UserInvitation:
   days_to_expiry: 2 # Days until an invitation expires
+  from_email: '' # Sender address for invitation emails. Falls back to Email.admin_email when empty.
 
 Dynamic\SilverStripe\UserInvitations\Control\UserController:
   back_url: ''

--- a/src/Model/UserInvitation.php
+++ b/src/Model/UserInvitation.php
@@ -48,6 +48,13 @@ class UserInvitation extends DataObject
     private static $force_require_group = false;
 
     /**
+     * Sender address for invitation emails. Falls back to Email.admin_email when empty.
+     * If both are empty, sendInvitation() throws a RuntimeException.
+     * @config
+     */
+    private static string $from_email = '';
+
+    /**
      * @config
      */
     private static $db = [
@@ -118,16 +125,32 @@ class UserInvitation extends DataObject
     }
 
     /**
+     * Resolves the From address for invitation emails.
+     * Prefers UserInvitation.from_email, falls back to Email.admin_email.
+     * @throws \RuntimeException if neither config value is set
+     */
+    private function resolveFromEmail(): string
+    {
+        $from = self::config()->get('from_email') ?: Email::config()->get('admin_email');
+        if (empty($from)) {
+            throw new \RuntimeException(
+                'UserInvitation: set UserInvitation.from_email or Email.admin_email before sending invitations.'
+            );
+        }
+        return $from;
+    }
+
+    /**
      * Sends an invitation to the desired user
      */
     public function sendInvitation()
     {
         $email = Email::create()
-            ->setFrom(Email::config()->get('admin_email'))
+            ->setFrom($this->resolveFromEmail())
             ->setTo($this->Email)
             ->setSubject(
                 _t(
-                    'UserInvation.EMAIL_SUBJECT',
+                    'UserInvitation.EMAIL_SUBJECT',
                     'Invitation from {name}',
                     ['name' => $this->InvitedBy()->FirstName]
                 )

--- a/src/Model/UserInvitation.php
+++ b/src/Model/UserInvitation.php
@@ -131,7 +131,7 @@ class UserInvitation extends DataObject
      */
     private function resolveFromEmail(): string
     {
-        $from = self::config()->get('from_email') ?: Email::config()->get('admin_email');
+        $from = (string)(self::config()->get('from_email') ?: Email::config()->get('admin_email'));
         if (empty($from)) {
             throw new \RuntimeException(
                 'UserInvitation: set UserInvitation.from_email or Email.admin_email before sending invitations.'

--- a/tests/php/UserInvitationTest.php
+++ b/tests/php/UserInvitationTest.php
@@ -4,6 +4,8 @@ namespace Dynamic\SilverStripe\UserInvitations\Tests;
 
 use SilverStripe\Dev\Debug;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Control\Email\Email;
+use SilverStripe\Core\Config\Config;
 use Dynamic\SilverStripe\UserInvitations\Model\UserInvitation;
 
 class UserInvitationTest extends SapphireTest
@@ -16,19 +18,53 @@ class UserInvitationTest extends SapphireTest
     }
 
     /**
-     * Tests that an invitation email was sent.
+     * Tests that sendInvitation() uses UserInvitation.from_email when configured.
      */
-    public function testSendInvitation()
+    public function testSendInvitationUsesFromEmailConfig(): void
     {
-        $this->markTestSkipped();
+        Config::inst()->set(UserInvitation::class, 'from_email', 'invites@example.org');
+        Config::inst()->set(Email::class, 'admin_email', '');
+
+        /** @var UserInvitation $joe */
+        $joe = $this->objFromFixture(UserInvitation::class, 'joe');
+        $sent = $joe->sendInvitation();
+
+        $from = $sent->getFrom();
+        $this->assertCount(1, $from);
+        $this->assertEquals('invites@example.org', $from[0]->getAddress());
+    }
+
+    /**
+     * Tests that sendInvitation() falls back to Email.admin_email when from_email is not set.
+     */
+    public function testSendInvitationFallsBackToAdminEmail(): void
+    {
+        Config::inst()->set(UserInvitation::class, 'from_email', '');
+        Config::inst()->set(Email::class, 'admin_email', 'noreply@example.org');
+
+        /** @var UserInvitation $joe */
+        $joe = $this->objFromFixture(UserInvitation::class, 'joe');
+        $sent = $joe->sendInvitation();
+
+        $from = $sent->getFrom();
+        $this->assertCount(1, $from);
+        $this->assertEquals('noreply@example.org', $from[0]->getAddress());
+    }
+
+    /**
+     * Tests that sendInvitation() throws a RuntimeException when neither address is configured.
+     */
+    public function testSendInvitationThrowsWhenNoFromConfigured(): void
+    {
+        Config::inst()->set(UserInvitation::class, 'from_email', '');
+        Config::inst()->set(Email::class, 'admin_email', '');
+
         /** @var UserInvitation $joe */
         $joe = $this->objFromFixture(UserInvitation::class, 'joe');
 
-        $sent = $joe->sendInvitation();
-        $keys = array_keys($sent->getTo());
-        $this->assertEquals($joe->Email, $keys[0]);
-        $this->assertEquals("Invitation from {$joe->InvitedBy()->FirstName}", $sent->getSubject());
-        $this->assertContains('Click here to accept this invitation', $sent->getBody());
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/from_email.*admin_email/');
+        $joe->sendInvitation();
     }
 
     /**
@@ -106,15 +142,15 @@ class UserInvitationTest extends SapphireTest
     {
         /** @var UserInvitation $joe */
         $joe = $this->objFromFixture(UserInvitation::class, 'joe');
-        
+
         $link = $joe->getInvitationLink();
-        
+
         // Should contain the base URL path
         $this->assertStringContainsString('/user/accept/', $link);
-        
+
         // Should contain the TempHash
         $this->assertStringContainsString($joe->TempHash, $link);
-        
+
         // Should be a valid URL format
         $this->assertMatchesRegularExpression('#^https?://.+/user/accept/[a-f0-9]+$#', $link);
     }


### PR DESCRIPTION
## Summary

- `sendInvitation()` was calling `->setFrom(Email::config()->get('admin_email'))` with no null/empty guard — if `Email.admin_email` is unset (common on fresh SS6 installs), Symfony Mailer throws `RfcComplianceException` and the invitation is silently never sent.
- Adds a `resolveFromEmail()` helper with a prioritised fallback chain: `UserInvitation.from_email` → `Email.admin_email` → `RuntimeException` with a clear message.
- Adds `from_email: ''` to `_config/config.yml` (documented, empty default — projects set it to customise the sender address).
- Fixes i18n key typo: `UserInvation.EMAIL_SUBJECT` → `UserInvitation.EMAIL_SUBJECT`.
- Replaces `markTestSkipped()` in `UserInvitationTest::testSendInvitation()` with 3 real coverage cases.

Closes #28. Supersedes #4.

## Test plan

- [ ] `ddev exec vendor/bin/phpunit vendor/dynamic/silverstripe-user-invitation/tests/` → 28/28 green (1 pre-existing skip)
- [ ] Set `Email.admin_email` in project config → create `UserInvitation` in `/admin` → **Send invitation** → confirm email arrives in Mailpit with a valid From address
- [ ] Temporarily remove `admin_email` → confirm the admin CMS shows a clear `RuntimeException` message rather than a generic error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XKWsQviZUjXB21ynqrywj8