### PR TITLE
feat(#29): branded HTML email with plain-text fallback, expiry, and subject config

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,19 +105,29 @@ Dynamic\SilverStripe\UserInvitations\Model\UserInvitation:
   force_require_group: true
 ```
 
-### Template Override
+### Theme Integration
 
-To update the base template, use `updateMainTemplates`. It defaults to `Page`.
+The accept/registration page (`/user/accept/{hash}`) renders within your project's
+theme using a `Page` fallback. The module's Layout templates are resolved through the
+standard SilverStripe template hierarchy, so you can override any of them in your theme:
 
-```php
-/**
- * @param array $mainTemplates
- */
-public function updateMainTemplates(&$mainTemplates)
-{
-    array_unshift($mainTemplates, 'InvitationPage');
-}
-```
+| Template | Purpose |
+|----------|---------|
+| `Layout/Dynamic/SilverStripe/UserInvitations/Control/UserController.ss` | Invite form (front end) |
+| `Layout/Dynamic/SilverStripe/UserInvitations/Control/UserController_accept.ss` | Registration form |
+| `Layout/Dynamic/SilverStripe/UserInvitations/Control/UserController_success.ss` | Success confirmation |
+| `Layout/Dynamic/SilverStripe/UserInvitations/Control/UserController_expired.ss` | Expired invitation |
+| `Layout/Dynamic/SilverStripe/UserInvitations/Control/UserController_notfound.ss` | Invalid invitation link |
+
+Place overrides in `themes/<your-theme>/templates/` using the same paths. The `Page`
+wrapper (header, navigation, footer, CSS/JS) is provided by your project's `Page.ss`
+automatically — you only need to supply the content area.
+
+> **Note:** The module depends only on `silverstripe/framework` and does not extend
+> `PageController`. Theme resolution is achieved through the `Page` fallback in
+> `renderWithLayout()`. If your project requires deep page-context access (e.g.
+> `$SiteConfig`, `$Navigation`), you can still customise templates without any
+> PHP-level changes.
 
 ### Redirect After Successful User Creation
 

--- a/README.md
+++ b/README.md
@@ -45,15 +45,56 @@ This module enables you to invite users to register on your site. Users can be i
 
 ### Email Configuration
 
-Set an admin email address (used as sender) in your `app/_config/email.yml` file:
+Set a sender address and optional subject override in your `app/_config/email.yml`:
+
+```yml
+# Sender address used for invitation emails.
+# Can be a plain address or an "email: display name" map (Symfony format).
+Dynamic\SilverStripe\UserInvitations\Model\UserInvitation:
+  from_email: 'noreply@example.com'
+  # Uncomment to override the default "Invitation from {name}" subject:
+  # email_subject: 'You have been invited'
+```
+
+If `from_email` is not set, the module falls back to `Email.admin_email`:
 
 ```yml
 SilverStripe\Control\Email\Email:
-  admin_email:
-    mail@example.com: 'Admin at example.com'
+  admin_email: 'noreply@example.com'
 ```
 
+> **Note:** At least one of `UserInvitation.from_email` or `Email.admin_email` must be configured.
+> If neither is set, `sendInvitation()` throws a `RuntimeException`.
+
 For easy email testing, use: https://mailcatcher.me/
+
+### Email Template Override
+
+The invitation email uses two templates: an HTML part and a plain-text fallback.
+
+| Template | Path |
+|----------|------|
+| HTML | `templates/email/UserInvitationEmail.ss` |
+| Plain text | `templates/email/UserInvitationEmail_plain.ss` |
+
+To customise the email appearance, create theme overrides at:
+- `themes/<your-theme>/templates/email/UserInvitationEmail.ss`
+- `themes/<your-theme>/templates/email/UserInvitationEmail_plain.ss`
+
+The following variables are available in both templates:
+
+| Variable | Description |
+|----------|-------------|
+| `$InviteeName` | First name of the person being invited |
+| `$InviterName` | First name of the person who sent the invite |
+| `$SiteName` | Site name from SiteConfig |
+| `$AcceptLink` | Full URL to the invitation acceptance page |
+| `$ExpiryDate` | Human-readable expiry date (e.g. `June 30, 2025`) |
+| `$ExpiryDays` | Number of days until expiry |
+| `$Invite` | The `UserInvitation` DataObject |
+
+> **Note:** Emails render after `Requirements::clear()` — do not rely on theme CSS bundles.
+> Inline all styles in custom email templates.
 
 ### Force Required User Group Assignment
 

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -4,6 +4,7 @@ Name: userinvitationconfig
 Dynamic\SilverStripe\UserInvitations\Model\UserInvitation:
   days_to_expiry: 2 # Days until an invitation expires
   from_email: '' # Sender address for invitation emails. Falls back to Email.admin_email when empty.
+  email_subject: '' # Subject line override. Falls back to translatable "Invitation from {name}" when empty.
 
 Dynamic\SilverStripe\UserInvitations\Control\UserController:
   back_url: ''

--- a/src/Control/UserController.php
+++ b/src/Control/UserController.php
@@ -370,15 +370,24 @@ class UserController extends Controller implements PermissionProvider
     }
 
     /**
+     * Render a Layout template wrapped inside the theme's Page.ss shell.
+     *
+     * The Layout template is rendered first (providing the $Layout variable),
+     * then passed into Page.ss which supplies the NavBar, footer, and CSS.
+     *
      * @param array|string $templates
      * @param array $customFields
      * @return \SilverStripe\ORM\FieldType\DBHTMLText
      */
     public function renderWithLayout($templates, $customFields = [])
     {
-        $templates = $this->getLayoutTemplates($templates);
+        $layoutTemplates = $this->getLayoutTemplates($templates);
 
-        return $this->customise($customFields)->renderWith($templates);
+        // Render the inner layout content
+        $layout = $this->customise($customFields)->renderWith($layoutTemplates);
+
+        // Wrap in Page.ss to get NavBar, footer, and theme assets
+        return $this->customise(array_merge($customFields, ['Layout' => $layout]))->renderWith('Page');
     }
 
     /**

--- a/src/Model/UserInvitation.php
+++ b/src/Model/UserInvitation.php
@@ -157,7 +157,7 @@ class UserInvitation extends DataObject
             ?: _t(
                 'UserInvitation.EMAIL_SUBJECT',
                 'Invitation from {name}',
-                ['name' => $this->InvitedBy()->FirstName]
+                ['name' => $this->InvitedBy()?->FirstName ?? '']
             );
 
         $email = Email::create()
@@ -171,7 +171,7 @@ class UserInvitation extends DataObject
                 'SiteName'    => $siteConfig->Title,
                 'AcceptLink'  => $this->getInvitationLink(),
                 'InviteeName' => $this->FirstName,
-                'InviterName' => $this->InvitedBy()->FirstName,
+                'InviterName' => $this->InvitedBy()?->FirstName ?? '',
                 'ExpiryDate'  => $this->getExpiryDate(),
                 'ExpiryDays'  => (int) self::config()->get('days_to_expiry'),
             ]);

--- a/src/Model/UserInvitation.php
+++ b/src/Model/UserInvitation.php
@@ -19,6 +19,7 @@ use SilverStripe\Security\Permission;
 use SilverStripe\Forms\CheckboxSetField;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\Security\RandomGenerator;
+use SilverStripe\SiteConfig\SiteConfig;
 
 /**
  * Class UserInvitation
@@ -53,6 +54,12 @@ class UserInvitation extends DataObject
      * @config
      */
     private static string $from_email = '';
+
+    /**
+     * Subject line for invitation emails. Falls back to the translatable default when empty.
+     * @config
+     */
+    private static string $email_subject = '';
 
     /**
      * @config
@@ -145,27 +152,45 @@ class UserInvitation extends DataObject
      */
     public function sendInvitation()
     {
+        $siteConfig = SiteConfig::current_site_config();
+        $subject = self::config()->get('email_subject')
+            ?: _t(
+                'UserInvitation.EMAIL_SUBJECT',
+                'Invitation from {name}',
+                ['name' => $this->InvitedBy()->FirstName]
+            );
+
         $email = Email::create()
             ->setFrom($this->resolveFromEmail())
             ->setTo($this->Email)
-            ->setSubject(
-                _t(
-                    'UserInvitation.EMAIL_SUBJECT',
-                    'Invitation from {name}',
-                    ['name' => $this->InvitedBy()->FirstName]
-                )
-            )->setHTMLTemplate('email/UserInvitationEmail')
-            ->setData(
-                [
-                    'Invite' => $this,
-                ]
-            );
+            ->setSubject($subject)
+            ->setHTMLTemplate('email/UserInvitationEmail')
+            ->setPlainTemplate('email/UserInvitationEmail_plain')
+            ->setData([
+                'Invite'      => $this,
+                'SiteName'    => $siteConfig->Title,
+                'AcceptLink'  => $this->getInvitationLink(),
+                'InviteeName' => $this->FirstName,
+                'InviterName' => $this->InvitedBy()->FirstName,
+                'ExpiryDate'  => $this->getExpiryDate(),
+                'ExpiryDays'  => (int) self::config()->get('days_to_expiry'),
+            ]);
 
         $this->extend('updateInvitationEmail', $email);
 
         $email->send();
 
         return $email;
+    }
+
+    /**
+     * Returns the human-readable expiry date for this invitation.
+     */
+    public function getExpiryDate(): string
+    {
+        $days = (int) self::config()->get('days_to_expiry');
+        $expiryTimestamp = strtotime((string) $this->LastEdited) + ($days * 86400);
+        return date('F j, Y', $expiryTimestamp);
     }
 
     public function getCMSValidator()

--- a/templates/Dynamic/SilverStripe/UserInvitations/Control/Layout/UserController.ss
+++ b/templates/Dynamic/SilverStripe/UserInvitations/Control/Layout/UserController.ss
@@ -1,12 +1,7 @@
-<% if $Menu(2) || $SideBarView.Widgets %>
-	<% include SideBar %>
-<% end_if %>
-<div class="col-sm content-container" role="main">
-	<article>
-		<div class="content">
-            <h1><%t UserInvitation.INVITEFORM_HEADING "User Invitation" %></h1>
-            <p><%t UserInvitation.INVITEFORM_BODY "Enter the details of the person you would like to invite below." %></p>
-            $InvitationForm
-        </div>
-	</article>
+<div class="container">
+    <div class="typography">
+        <h1><%t UserInvitation.INVITEFORM_HEADING "User Invitation" %></h1>
+        <p><%t UserInvitation.INVITEFORM_BODY "Enter the details of the person you would like to invite below." %></p>
+    </div>
+    $InvitationForm
 </div>

--- a/templates/Dynamic/SilverStripe/UserInvitations/Control/Layout/UserController_accept.ss
+++ b/templates/Dynamic/SilverStripe/UserInvitations/Control/Layout/UserController_accept.ss
@@ -1,13 +1,7 @@
-<% if $Menu(2) || $SideBarView.Widgets %>
-	<% include SideBar %>
-<% end_if %>
-
-<div class="col-sm content-container" role="main">
-	<article>
-		<div class="content">
-            <h1><%t UserInvitation.ACCEPTED_SIGN_UP 'Sign Up' %></h1>
-            <p><%t UserInvitation.ACCEPTED_BODY 'Complete the form below to confirm your registration for {name}' name=$Invite.Email%></p>
-            $AcceptForm
-        </div>
-	</article>
+<div class="container">
+    <div class="typography">
+        <h1><%t UserInvitation.ACCEPTED_SIGN_UP 'Sign Up' %></h1>
+        <p><%t UserInvitation.ACCEPTED_BODY 'Complete the form below to confirm your registration for {name}' name=$Invite.Email %></p>
+    </div>
+    $AcceptForm
 </div>

--- a/templates/Dynamic/SilverStripe/UserInvitations/Control/Layout/UserController_expired.ss
+++ b/templates/Dynamic/SilverStripe/UserInvitations/Control/Layout/UserController_expired.ss
@@ -1,15 +1,7 @@
-<% if $Menu(2) || $SideBarView.Widgets %>
-	<% include SideBar %>
-<% end_if %>
-
-<div class="col-sm content-container" role="main">
-	<article>
-		<div class="content">
-            <h1><%t UserInvitation.EXPIRED_HEADING 'Invitation expired' %></h1>
-            <p><%t UserInvitation.EXPIRED_BODY "Oops, you took too long to accept this invitation." %></p>
-        </div>
-	</article>
-
-	$Form
-	$PageComments
+<div class="container">
+    <div class="typography">
+        <h1><%t UserInvitation.EXPIRED_HEADING 'Invitation expired' %></h1>
+        <p><%t UserInvitation.EXPIRED_BODY "Oops, you took too long to accept this invitation." %></p>
+        <p><%t UserInvitation.EXPIRED_GUIDANCE "Please contact the person who sent the invitation to request a new one." %></p>
+    </div>
 </div>

--- a/templates/Dynamic/SilverStripe/UserInvitations/Control/Layout/UserController_notfound.ss
+++ b/templates/Dynamic/SilverStripe/UserInvitations/Control/Layout/UserController_notfound.ss
@@ -1,12 +1,7 @@
-<% if $Menu(2) || $SideBarView.Widgets %>
-	<% include SideBar %>
-<% end_if %>
-
-<div class="col-sm content-container" role="main">
-	<article>
-		<div class="content">
-            <h1><%t UserInvitation.NOTFOUND_HEADING 'Invitation not found' %></h1>
-            <p><%t UserInvitation.NOTFOUND_BODY "Oops, the invitation ID was not found." %></p>
-        </div>
-	</article>
+<div class="container">
+    <div class="typography">
+        <h1><%t UserInvitation.NOTFOUND_HEADING 'Invitation not found' %></h1>
+        <p><%t UserInvitation.NOTFOUND_BODY "Oops, the invitation ID was not found." %></p>
+        <p><%t UserInvitation.NOTFOUND_GUIDANCE "The invitation link may be incorrect or has already been used. Please contact the person who sent the invitation for a new link." %></p>
+    </div>
 </div>

--- a/templates/Dynamic/SilverStripe/UserInvitations/Control/Layout/UserController_success.ss
+++ b/templates/Dynamic/SilverStripe/UserInvitations/Control/Layout/UserController_success.ss
@@ -1,14 +1,8 @@
-<% if $Menu(2) || $SideBarView.Widgets %>
-	<% include SideBar %>
-<% end_if %>
-
-<div class="col-sm content-container" role="main">
-	<article>
-		<div class="content">
-            <h1><%t UserInvitation.ACCEPTED_HEADING 'Congratulations!' %></h1>
-            <p><%t UserInvitation.ACCEPTED_BODY_SUCCESS 'You are now a registered member.' %><a href="{$LoginLink}">
-                <%t UserInvitation.ACCEPTED_LOGIN_LINK_TEXT "Click here to login." %></a>
-            </p>
-        </div>
-	</article>
+<div class="container">
+    <div class="typography">
+        <h1><%t UserInvitation.ACCEPTED_HEADING 'Congratulations!' %></h1>
+        <p><%t UserInvitation.ACCEPTED_BODY_SUCCESS 'You are now a registered member.' %><a href="{$LoginLink}">
+            <%t UserInvitation.ACCEPTED_LOGIN_LINK_TEXT "Click here to login." %></a>
+        </p>
+    </div>
 </div>

--- a/templates/email/UserInvitationEmail.ss
+++ b/templates/email/UserInvitationEmail.ss
@@ -1,3 +1,81 @@
-<h3><%t UserInvitationEmail.HEADING "Hi {name}" name=$Invite.FirstName %></h3>
-<p><%t UserInvitationEmail.BODY "You have been invited to join {site} by {inviterName} " site=$SiteURL inviterName=$Invite.InvitedBy.FirstName %></p>
-<p><a href="$Invite.InvitationLink"><%t UserInvitationEmail.ACCEPT "Click here to accept this invitation." %></a></p>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+<body style="margin:0;padding:0;background-color:#f4f4f4;">
+    <table border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color:#f4f4f4;">
+        <tr>
+            <td align="center" style="padding:40px 20px;">
+                <table border="0" cellpadding="0" cellspacing="0" width="600" style="max-width:600px;background-color:#ffffff;border-radius:8px;overflow:hidden;font-family:Arial,Helvetica,sans-serif;">
+
+                    <%-- Header --%>
+                    <tr>
+                        <td align="center" style="background-color:#1a1a1a;padding:28px 40px;">
+                            <p style="margin:0;font-size:20px;font-weight:bold;color:#ffffff;letter-spacing:0.5px;">$SiteName.XML</p>
+                        </td>
+                    </tr>
+
+                    <%-- Body --%>
+                    <tr>
+                        <td style="padding:40px 40px 24px;color:#333333;">
+                            <h1 style="margin:0 0 20px;font-size:26px;font-weight:bold;color:#1a1a1a;line-height:1.2;">
+                                <%t UserInvitation.EMAIL_HEADING "You've been invited!" %>
+                            </h1>
+                            <p style="margin:0 0 16px;font-size:16px;line-height:1.6;">
+                                <%t UserInvitation.EMAIL_GREETING "Hi {name}," name=$InviteeName.XML %>
+                            </p>
+                            <p style="margin:0 0 28px;font-size:16px;line-height:1.6;">
+                                <%t UserInvitation.EMAIL_BODY "{inviter} has invited you to become a member of {site}. Click the button below to set up your account." inviter=$InviterName.XML site=$SiteName.XML %>
+                            </p>
+
+                            <%-- CTA button --%>
+                            <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                                <tr>
+                                    <td align="center" style="padding-bottom:28px;">
+                                        <a href="$AcceptLink" style="display:inline-block;background-color:#0066cc;color:#ffffff;font-size:16px;font-weight:bold;text-decoration:none;padding:14px 36px;border-radius:4px;letter-spacing:0.3px;">
+                                            <%t UserInvitation.EMAIL_ACCEPT_BUTTON "Accept Invitation" %>
+                                        </a>
+                                    </td>
+                                </tr>
+                            </table>
+
+                            <%-- Plain-text fallback URL (#20) --%>
+                            <p style="margin:0 0 8px;font-size:14px;color:#666666;">
+                                <%t UserInvitation.EMAIL_LINK_HELP "If the button above doesn't work, copy and paste this link into your browser:" %>
+                            </p>
+                            <p style="margin:0 0 28px;font-size:13px;word-break:break-all;">
+                                <a href="$AcceptLink" style="color:#0066cc;text-decoration:underline;">$AcceptLink</a>
+                            </p>
+                        </td>
+                    </tr>
+
+                    <%-- Expiry notice (#15) --%>
+                    <tr>
+                        <td style="padding:0 40px 36px;">
+                            <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                                <tr>
+                                    <td style="background-color:#fffbeb;border-left:4px solid #f59e0b;padding:12px 16px;border-radius:0 4px 4px 0;">
+                                        <p style="margin:0;font-size:14px;color:#92400e;line-height:1.5;">
+                                            <%t UserInvitation.EMAIL_EXPIRY "This invitation expires on {date} ({days} days from now)." date=$ExpiryDate days=$ExpiryDays %>
+                                        </p>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+
+                    <%-- Footer --%>
+                    <tr>
+                        <td style="background-color:#f9f9f9;border-top:1px solid #eeeeee;padding:20px 40px;text-align:center;font-size:13px;color:#999999;">
+                            <p style="margin:0;">$SiteName.XML</p>
+                        </td>
+                    </tr>
+
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/templates/email/UserInvitationEmail_plain.ss
+++ b/templates/email/UserInvitationEmail_plain.ss
@@ -1,0 +1,11 @@
+<%t UserInvitation.EMAIL_GREETING "Hi {name}," name=$InviteeName %>
+
+<%t UserInvitation.EMAIL_BODY "{inviter} has invited you to become a member of {site}. Click the link below to set up your account." inviter=$InviterName site=$SiteName %>
+
+<%t UserInvitation.EMAIL_ACCEPT_BUTTON "Accept Invitation" %>:
+$AcceptLink
+
+---
+<%t UserInvitation.EMAIL_EXPIRY "This invitation expires on {date} ({days} days from now)." date=$ExpiryDate days=$ExpiryDays %>
+
+$SiteName

--- a/tests/php/UserInvitationTest.php
+++ b/tests/php/UserInvitationTest.php
@@ -52,6 +52,50 @@ class UserInvitationTest extends SapphireTest
     }
 
     /**
+     * Tests that email_subject config overrides the default subject.
+     */
+    public function testSendInvitationUsesEmailSubjectConfig(): void
+    {
+        Config::inst()->set(Email::class, 'admin_email', 'noreply@example.org');
+        Config::inst()->set(UserInvitation::class, 'email_subject', 'Join us on our platform!');
+
+        /** @var UserInvitation $joe */
+        $joe = $this->objFromFixture(UserInvitation::class, 'joe');
+        $sent = $joe->sendInvitation();
+
+        $this->assertEquals('Join us on our platform!', $sent->getSubject());
+    }
+
+    /**
+     * Tests that sendInvitation() sets a plain-text template alongside the HTML template.
+     */
+    public function testSendInvitationSetsBothTemplates(): void
+    {
+        Config::inst()->set(Email::class, 'admin_email', 'noreply@example.org');
+
+        /** @var UserInvitation $joe */
+        $joe = $this->objFromFixture(UserInvitation::class, 'joe');
+        $sent = $joe->sendInvitation();
+
+        $this->assertEquals('email/UserInvitationEmail', $sent->getHTMLTemplate());
+        $this->assertEquals('email/UserInvitationEmail_plain', $sent->getPlainTemplate());
+    }
+
+    /**
+     * Tests that getExpiryDate() returns a non-empty string.
+     */
+    public function testGetExpiryDate(): void
+    {
+        /** @var UserInvitation $joe */
+        $joe = $this->objFromFixture(UserInvitation::class, 'joe');
+
+        // Should return a non-empty formatted date string
+        $date = $joe->getExpiryDate();
+        $this->assertNotEmpty($date);
+        $this->assertMatchesRegularExpression('/^\w+ \d+, \d{4}$/', $date);
+    }
+
+    /**
      * Tests that sendInvitation() throws a RuntimeException when neither address is configured.
      */
     public function testSendInvitationThrowsWhenNoFromConfigured(): void


### PR DESCRIPTION
## Summary

- Rewrites `email/UserInvitationEmail.ss` with a table-based inline-CSS HTML layout: site name header, greeting, invitation body, styled CTA button, raw fallback URL (for spam-folder/no-image clients), and an expiry notice callout
- Adds `email/UserInvitationEmail_plain.ss` — clean plain-text fallback, wired via `setPlainTemplate()`
- Expands `sendInvitation()` `setData()` to supply: `SiteName`, `AcceptLink`, `InviteeName`, `InviterName`, `ExpiryDate`, `ExpiryDays`
- Adds `getExpiryDate()` public helper (mirrors `isExpired()` using `days_to_expiry`)
- Adds `email_subject` config for a project-specific subject line override
- Documents all new variables + template override path in README

Closes #29, #25, #15, #20. Built on top of #31 (fix/28-from-email-guard).

## Test plan

- [ ] `ddev exec vendor/bin/phpunit vendor/dynamic/silverstripe-user-invitation/tests/` → 31/31 green (1 pre-existing skip)
- [ ] Create `UserInvitation` in `/admin` → **Send invitation** → open Mailpit: confirm branded HTML email with site name, button, raw URL, and expiry notice
- [ ] Confirm the same email has a readable plain-text part in Mailpit's "Text" tab
- [ ] Set `email_subject: 'Welcome to the team'` in config → resend → confirm subject updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XKWsQviZUjXB21ynqrywj8