### PR TITLE
fix(#34): declare silverstripe/siteconfig dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     "require": {
         "php": "^8.3",
         "silverstripe/framework": "^6",
+        "silverstripe/siteconfig": "^6",
         "lekoala/silverstripe-cms-actions": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
Fixes #34.

## Problem
`UserInvitation::sendInvitation()` calls `SiteConfig::current_site_config()` (`src/Model/UserInvitation.php:155`, imported line 22) to set the invitation email's `SiteName`, but `composer.json` never declared `silverstripe/siteconfig`. On framework-only installs (no `silverstripe/cms` / `recipe-cms`) the class is absent and sending an invite fatals:

```
Uncaught Error: Class "SilverStripe\SiteConfig\SiteConfig" not found
  at src/Model/UserInvitation.php line 155
```

Hidden on full-CMS installs (siteconfig comes in transitively); fatal on minimal ones.

## Fix
Declare `"silverstripe/siteconfig": "^6"` in `require`. Latest 6.x (6.1.1) requires `silverstripe/framework: ^6.1`, consistent with this module's `framework: ^6`.

## Notes
One-line dependency declaration; no code change. Suggest tagging a patch release (2.1.1) so `^2.1` consumers pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)