### PR TITLE
Add configurable password-requirements help text to AcceptForm

### DIFF
--- a/lang/de.yml
+++ b/lang/de.yml
@@ -49,6 +49,7 @@ de:
     SENT_INVITATION: "Eine Einladung wurde an {email} gesendet."
     ACCEPTFORM_FIRSTNAME: "Vorname:"
     ACCEPTFORM_SURNAME: "Nachname:"
+    ACCEPTFORM_PASSWORD_DESCRIPTION: "Ein von einem Passwort-Manager generiertes Passwort oder eine Passphrase aus mehreren zufälligen Wörtern funktioniert am besten. Kurze oder vorhersehbare Passwörter werden oft abgelehnt, selbst mit Zahlen und Symbolen."
     ACCEPTFORM_REGISTER: "Registrieren"
     403_NOTICE: "Sie müssen eingeloggt sein, um auf diese Seite zugreifen zu können."
     ACCEPTED_BODY: "Sie sind jetzt ein registriertes Mitglied."

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -32,6 +32,7 @@ en:
     SENT_INVITATION: 'An invitation was sent to {email}.'
     ACCEPTFORM_FIRSTNAME: 'First name:'
     ACCEPTFORM_SURNAME: 'Surname:'
+    ACCEPTFORM_PASSWORD_DESCRIPTION: 'A password manager-generated password or a passphrase of several random words works best. Short or predictable passwords are often rejected even with numbers and symbols.'
     ACCEPTFORM_REGISTER: 'Register'
     403_NOTICE: 'You must be logged in to access this page.'
     ACCEPTED_BODY: 'You are now a registered member.'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/silverstripe/cms/tests/bootstrap.php" colors="true">
+<phpunit bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true">
     <testsuites>
         <testsuite name="Default">
             <directory>tests/</directory>

--- a/src/Control/UserController.php
+++ b/src/Control/UserController.php
@@ -40,6 +40,18 @@ class UserController extends Controller implements PermissionProvider
         'notfound',
     ];
 
+    /**
+     * Help text shown under the Password field on AcceptForm. The site's password
+     * validator (SilverStripe core's default) is typically strength/entropy-based rather
+     * than a fixed character-class checklist, so there's no simple rule ("8 chars + a
+     * number") that reliably predicts a pass. Set to null/empty in project config to
+     * suppress this text entirely.
+     *
+     * @config
+     * @var string|null
+     */
+    private static $password_description = null;
+
     public function providePermissions()
     {
         return [
@@ -217,6 +229,16 @@ class UserController extends Controller implements PermissionProvider
         $invite = UserInvitation::get()->filter('TempHash', $hash)->first();
         $firstName = ($invite) ? $invite->FirstName : '';
 
+        $passwordField = ConfirmedPasswordField::create('Password');
+        $passwordDescription = static::config()->get('password_description') ?? _t(
+            'UserController.ACCEPTFORM_PASSWORD_DESCRIPTION',
+            'A password manager-generated password or a passphrase of several random words '
+            . 'works best. Short or predictable passwords are often rejected even with numbers and symbols.'
+        );
+        if ($passwordDescription) {
+            $passwordField->setDescription($passwordDescription);
+        }
+
         $fields = FieldList::create(
             TextField::create(
                 'FirstName',
@@ -227,7 +249,7 @@ class UserController extends Controller implements PermissionProvider
                 'Surname',
                 _t('UserController.ACCEPTFORM_SURNAME', 'Surname:')
             ),
-            ConfirmedPasswordField::create('Password'),
+            $passwordField,
             HiddenField::create('HashID')->setValue($hash)
         );
         $actions = FieldList::create(

--- a/src/Control/UserController.php
+++ b/src/Control/UserController.php
@@ -44,8 +44,10 @@ class UserController extends Controller implements PermissionProvider
      * Help text shown under the Password field on AcceptForm. The site's password
      * validator (SilverStripe core's default) is typically strength/entropy-based rather
      * than a fixed character-class checklist, so there's no simple rule ("8 chars + a
-     * number") that reliably predicts a pass. Set to null/empty in project config to
-     * suppress this text entirely.
+     * number") that reliably predicts a pass. Leave unset to use the built-in default
+     * message; set to an empty string in project config to suppress this text entirely.
+     * (Config has no way to distinguish an explicitly-configured null from an unconfigured
+     * value, so null does not suppress it - only an empty string does.)
      *
      * @config
      * @var string|null
@@ -235,7 +237,7 @@ class UserController extends Controller implements PermissionProvider
             'A password manager-generated password or a passphrase of several random words '
             . 'works best. Short or predictable passwords are often rejected even with numbers and symbols.'
         );
-        if ($passwordDescription) {
+        if ($passwordDescription !== '') {
             $passwordField->setDescription($passwordDescription);
         }
 

--- a/tests/php/UserControllerTest.php
+++ b/tests/php/UserControllerTest.php
@@ -233,9 +233,22 @@ class UserControllerTest extends FunctionalTest
         $passwordField = $this->controller->AcceptForm()->Fields()->dataFieldByName('Password');
         $this->assertSame('Custom help text', $passwordField->getDescription());
 
+        // A single-character "0" is falsy in PHP but a legitimate configured value; it
+        // must be kept, not silently dropped by a truthiness check.
+        Config::modify()->set(UserController::class, 'password_description', '0');
+        $passwordField = $this->controller->AcceptForm()->Fields()->dataFieldByName('Password');
+        $this->assertSame('0', $passwordField->getDescription());
+
         Config::modify()->set(UserController::class, 'password_description', '');
         $passwordField = $this->controller->AcceptForm()->Fields()->dataFieldByName('Password');
         $this->assertEmpty($passwordField->getDescription());
+
+        // Explicitly setting null is indistinguishable from leaving it unconfigured, so
+        // it falls back to the built-in default rather than suppressing the text - only
+        // an empty string suppresses it. This locks in that documented behavior.
+        Config::modify()->set(UserController::class, 'password_description', null);
+        $passwordField = $this->controller->AcceptForm()->Fields()->dataFieldByName('Password');
+        $this->assertNotEmpty($passwordField->getDescription());
     }
 
     /**

--- a/tests/php/UserControllerTest.php
+++ b/tests/php/UserControllerTest.php
@@ -213,6 +213,32 @@ class UserControllerTest extends FunctionalTest
     }
 
     /**
+     * The Password field should carry help text by default, since the site's password
+     * validator is typically strength-based rather than a fixed checklist.
+     */
+    public function testAcceptFormPasswordDescription()
+    {
+        $form = $this->controller->AcceptForm();
+        $passwordField = $form->Fields()->dataFieldByName('Password');
+        $this->assertNotNull($passwordField);
+        $this->assertNotEmpty($passwordField->getDescription());
+    }
+
+    /**
+     * Project config can override or suppress the default password help text.
+     */
+    public function testAcceptFormPasswordDescriptionConfigurable()
+    {
+        Config::modify()->set(UserController::class, 'password_description', 'Custom help text');
+        $passwordField = $this->controller->AcceptForm()->Fields()->dataFieldByName('Password');
+        $this->assertSame('Custom help text', $passwordField->getDescription());
+
+        Config::modify()->set(UserController::class, 'password_description', '');
+        $passwordField = $this->controller->AcceptForm()->Fields()->dataFieldByName('Password');
+        $this->assertEmpty($passwordField->getDescription());
+    }
+
+    /**
      * Tests that redirected to not found if has not found
      */
     public function testSaveInviteWrongHashError()


### PR DESCRIPTION
## Summary

SilverStripe's default password validator (SS6's `EntropyPasswordValidator`) is strength/entropy-based rather than a fixed character-class checklist. There's no simple rule ("8 chars + a number + a symbol") that reliably predicts a pass — a password like `MyPassword1!` fails while a longer passphrase or password-manager string passes, depending on entropy, not just composition. Without guidance, users invited via `AcceptForm` are left guessing and retrying against an opaque check.

This surfaced in production: a client onboarded via this module's invite flow had a very hard time setting a password, retrying repeatedly until she used a browser-generated one. Root-caused to the framework's default validator, not anything project-specific — see [dynamic/project-feedback-installer#178](https://github.com/dynamic/project-feedback-installer/issues/178) for the investigation.

## Changes

- `AcceptForm()`'s `Password` field now gets a `setDescription()` with practical guidance (password manager or passphrase of random words), matching the actual strategies that clear entropy-based validation.
- The text is configurable via a new `password_description` config property (`UserController::class`), so consuming projects can override the wording or set it to an empty string to suppress it entirely. Defaults to a sensible built-in message via `_t()`, consistent with the module's existing i18n pattern.
- Two new tests cover the default text and the override/suppress behavior.

## Unrelated fix included

While setting up local test execution I found `phpunit.xml.dist` points its bootstrap at `vendor/silverstripe/cms/tests/bootstrap.php` — `silverstripe/cms` isn't a dependency of this branch (`composer.json` only requires `silverstripe/framework`), so this prevented the entire existing test suite from running at all, even before this PR's changes. Fixed to `vendor/silverstripe/framework/tests/bootstrap.php`, which resolved it.

## Testing

Ran the full `UserControllerTest` suite locally (PHP 8.5, standalone `composer install`, pointed at a throwaway MySQL DB) after the bootstrap fix:
- `testAcceptFormPasswordDescription` — new, passes
- `testAcceptFormPasswordDescriptionConfigurable` — new, passes
- `testAcceptForm` (pre-existing) — still passes unmodified
- 4 pre-existing failures (`Success`, `Expired`, `NotFound`, `renderWithLayout`) are all `MissingTemplateException: Page` — a standalone-test-environment gap (no consuming theme's `Page.ss` available in isolation), unrelated to this change and untouched by this diff.

`phpcs` (module's own `phpcs.xml.dist`) is clean on both modified files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDPnFsrcbsTfbopnfPZNQb